### PR TITLE
Remove undefined index notice in Writer\Xlsx\Worksheet

### DIFF
--- a/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
+++ b/src/PhpSpreadsheet/Writer/Xlsx/Worksheet.php
@@ -1072,7 +1072,9 @@ class Worksheet extends WriterPart
     {
         $objWriter->writeAttribute('t', $mappedType);
         if (!$cellValue instanceof RichText) {
-            self::writeElementIf($objWriter, isset($pFlippedStringTable[$cellValue]), 'v', $pFlippedStringTable[$cellValue]);
+            if (isset($pFlippedStringTable[$cellValue])) {
+                $objWriter->writeElement('v', $pFlippedStringTable[$cellValue]);
+            }    
         } else {
             $objWriter->writeElement('v', $pFlippedStringTable[$cellValue->getHashCode()]);
         }


### PR DESCRIPTION
Preventing a notice for undefined index when `$pFlippedStringTable`  does not contain index `$cellValue`.

This happened when `null` was being written to a string-cell.

This is:

```
- [x] a bugfix
- [ ] a new feature
```

Checklist:

- [x] Changes are covered by unit tests
- [x] Code style is respected
- [x] Commit message explains **why** the change is made (see https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
- [ ] CHANGELOG.md contains a short summary of the change
- [ ] Documentation is updated as necessary

### Why this change is needed?
This bug prevents me from saving xlsx's.